### PR TITLE
chore: use docker compose command

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "clean-testreport": "rimraf testreport/*",
     "copy-files": "mkdir testreport; docker cp Target-2:events.log testreport/target2_events.log; docker cp Target-1:events.log testreport/target1_events.log",
     "copy-logs": "mkdir testreport; docker compose logs > testreport/containers_console.log",
-    "docker-up": "docker-compose up -d --build",
-    "docker-down": "docker-compose down --rmi local -v",
+    "docker-up": "docker compose up -d --build",
+    "docker-down": "docker compose down --rmi local -v",
     "docker-restart": "npm run docker-down && npm run docker-up",
     "pretest": "npm run clean-testreport && npm run copy-files && npm run copy-logs",
     "test": "mocha ./**/*.js --timeout 10000 --reporter mochawesome --reporter-options reportDir=testreport,reportFilename=testreport"


### PR DESCRIPTION
Update `docker-up` and `docker-down` scripts to use the newer `docker compose up` and `docker compose down` commands, instead of `docker-compose up` / `docker-compose down`.