### PR TITLE
chore: update test script to startup/teardown containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ Pre-reqs for running the tests on your local machine:
 2. Run `npm install` to install all the test dependencies
 
 To run the tests (from a terminal):
-1. Make sure the split has been performed and the Docker containers are up (use either `npm run docker-restart` or `npm run docker-up`)
-2. Run `npm run test`
+1. Run `npm run test` - this will automatically start up the docker containers, run the tests, and then teardown the docker containers when the tests complete
 
 After a test run, the following are written to the `testreport` folder:
 1. `testreport.html` - mochawesome report showing the passed/failed test cases

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "docker-up": "docker compose up -d --build",
     "docker-down": "docker compose down --rmi local -v",
     "docker-restart": "npm run docker-down && npm run docker-up",
-    "pretest": "npm run clean-testreport && npm run copy-files && npm run copy-logs",
-    "test": "mocha ./**/*.js --timeout 10000 --reporter mochawesome --reporter-options reportDir=testreport,reportFilename=testreport"
+    "pretest": "npm run docker-restart && npm run clean-testreport && npm run copy-files && npm run copy-logs",
+    "test": "mocha ./**/*.js --timeout 10000 --reporter mochawesome --reporter-options reportDir=testreport,reportFilename=testreport; npm run docker-down"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Update package.json `test` script to automatically start up the docker containers before the tests run & then shutdown the docker containers when the tests end.