### PR TITLE
test: start/stop docker in before/after hook

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -16,13 +16,6 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Start containers
-        run: npm run docker-up
-
-      - name: Sleep for 5 seconds
-        run: sleep 5s
-        shell: bash       
-
       - name: Run tests
         run: npm run test
 
@@ -33,9 +26,5 @@ jobs:
           name: testreport
           path: testreport
           retention-days: 1
-
-      - name: Stop containers
-        if: always()
-        run: npm run docker-down
 
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/package.json
+++ b/package.json
@@ -5,13 +5,12 @@
   "main": "app.js",
   "scripts": {
     "clean-testreport": "rimraf testreport/*",
-    "copy-files": "mkdir testreport; docker cp Target-2:events.log testreport/target2_events.log; docker cp Target-1:events.log testreport/target1_events.log",
     "copy-logs": "mkdir testreport; docker compose logs > testreport/containers_console.log",
     "docker-up": "docker compose up -d --build",
     "docker-down": "docker compose down --rmi local -v",
     "docker-restart": "npm run docker-down && npm run docker-up",
-    "pretest": "npm run docker-restart && npm run clean-testreport && npm run copy-files && npm run copy-logs",
-    "test": "mocha ./**/*.js --timeout 10000 --reporter mochawesome --reporter-options reportDir=testreport,reportFilename=testreport; npm run docker-down"
+    "pretest": "npm run clean-testreport",
+    "test": "mocha ./**/*.js --timeout 10000 --reporter mochawesome --reporter-options reportDir=testreport,reportFilename=testreport"
   },
   "repository": {
     "type": "git",

--- a/test/test.js
+++ b/test/test.js
@@ -8,12 +8,13 @@ const spawn = require('child_process').spawn;
 const sqlite3 = require('sqlite3').verbose();
 let db = new sqlite3.Database('./test/events.db');
 
-let extendedTimeout = 60000;  // for long-running hooks or tests
+let extendedTimeout = 90000;  // for long-running hooks or tests
 
 // for reporting test case failures
 let errorMsg = '';
 let errorData = '';
-const failedTestsFolder = path.join(__dirname, '../testreport/failedTests');
+const testreportFolder = path.join(__dirname, '../testreport');
+const failedTestsFolder = path.join(testreportFolder, 'failedTests');
  
 /**
  * Insert each line from an events file into an events array.
@@ -107,7 +108,7 @@ describe('Events Splitter', function() {
 
     // copy the Target events files to the testreport folder
     console.log('copying Target event files');
-    if (!fs.existsSync('../testreport')) await fs.promises.mkdir('../testreport');
+    if (!fs.existsSync(testreportFolder)) await fs.promises.mkdir(testreportFolder);
     await runCommand('docker', ['cp', 'Target-1:events.log', 'testreport/target1_events.log']);
     await runCommand('docker', ['cp', 'Target-2:events.log', 'testreport/target2_events.log']);
 

--- a/test/test.js
+++ b/test/test.js
@@ -3,9 +3,12 @@ const { expect } = require('chai');
 const fs = require('fs');
 const readline = require('readline');
 const path = require('path');
+const spawn = require('child_process').spawn;
 
 const sqlite3 = require('sqlite3').verbose();
 let db = new sqlite3.Database('./test/events.db');
+
+let extendedTimeout = 60000;  // for long-running hooks or tests
 
 // for reporting test case failures
 let errorMsg = '';
@@ -63,6 +66,29 @@ async function arrayToDb(arr) {
   });
 }
 
+/**
+ * Run a command as a child process (e.g 'docker compose up'). Spawn is used in this method so that
+ * stdout is streamed instead of buffered.
+ * 
+ * @param {*} cmd the command to run, e.g 'docker'
+ * @param {*} args an array of args used by the cmd, e.g ['compose', 'up']
+ */
+async function runCommand(cmd, args) {
+  await new Promise((resolve, reject) => {
+    let child = spawn(cmd, args);
+    // display stdout on screen
+    child.stdout.on('data', function (data) {   process.stdout.write(data.toString());  });
+
+    // display stderr on screen
+    child.stderr.on('data', function (data) {   process.stdout.write(data.toString());  });
+
+    child.on('close', function (code) { 
+      console.log('finished with code ' + code);
+      resolve();
+    });
+  });  
+}
+
 describe('Events Splitter', function() {
 
   let agentEvents = [];
@@ -70,25 +96,47 @@ describe('Events Splitter', function() {
   let target2Events = [];
 
   before(async function() {
+    this.timeout(extendedTimeout);
 
+    // start docker
+    console.log('starting docker containers... this can take a minute');
+    await runCommand('npm', ['run', 'docker-restart']);
+
+    // wait 5 seconds for the Splitter to complete and the Target events.log files to be written
+    await new Promise((res) => setTimeout(res, 5000));
+
+    // copy the Target events files to the testreport folder
+    console.log('copying Target event files');
+    if (!fs.existsSync('../testreport')) await fs.promises.mkdir('../testreport');
+    await runCommand('docker', ['cp', 'Target-1:events.log', 'testreport/target1_events.log']);
+    await runCommand('docker', ['cp', 'Target-2:events.log', 'testreport/target2_events.log']);
+
+    // fill up the arrays with all rows from the agent / target1 / target2 files
     const agentFile = path.join(__dirname, '../agent/inputs/large_1M_events.log');
     const target1File = path.join(__dirname, '../testreport/target1_events.log');
     const target2File = path.join(__dirname, '../testreport/target2_events.log');
   
-    // fill up the arrays with all rows from the agent / target1 / target2 files
     await Promise.all([
         fileToArray(agentFile, agentEvents, 'Agent'),
         fileToArray(target1File, target1Events, 'Target1'),
         fileToArray(target2File, target2Events, 'Target2')
     ]);
-
   });
 
   after(async function() {
+    this.timeout(extendedTimeout);
+
     // copy the db to the testreports folder, clear out the data and close the db
     await fs.promises.copyFile('./test/events.db', './testreport/events.db');
     db.run("DELETE FROM events");
     db.close();    
+
+    // copy console logs from the containers to the testreport folder
+    await runCommand('npm', ['run', 'copy-logs']);
+
+    // shutdown docker containers
+    console.log('stopping docker...');
+    await runCommand('npm', ['run', 'docker-down']);
   });
 
   describe('Validate events', async function() {


### PR DESCRIPTION
This PR fixes issue:  https://github.com/clhobbs/events-splitter/issues/6

The docker containers are now started up in the `test.js` before hook.  Also, in the before hook: after the containers are up and the Events Splitter has completed, the Target events.log files are copied over to the `testreport` folder for use by the tests.

I also added code in the after hook to copy the container console logs to the  `testreport` folder and then shutdown the docker containers.

This change has also allowed me to simplify the Github Actions workflow (no longer a need to start/stop containers from the test-pr.yml file).