### PR TITLE
test: add extra report context to show where failedTest data is

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const readline = require('readline');
 const path = require('path');
 const spawn = require('child_process').spawn;
+const addContext = require('mochawesome/addContext')
 
 const sqlite3 = require('sqlite3').verbose();
 let db = new sqlite3.Database('./test/events.db');
@@ -166,6 +167,10 @@ describe('Events Splitter', function() {
         fs.writeFile(path.join(failedTestsFolder, filename), errorMsg + ':\n' + errorData, (err) => {
           if (err) console.log(err);
           else console.log("failedTest log file written successfully\n");
+        });
+        addContext(this, { 
+          title: 'Events data that caused this failure is in this file', 
+          value: `testreport/failedTests/${filename}`
         });
       }
     });


### PR DESCRIPTION
This is just an enhancement for issue https://github.com/clhobbs/events-splitter/issues/7

The tests produce files in the failedTests folder containing all of the data that caused a particular test to fail, but it was not apparent from the mochawesome report where that data is located.  I added this to each failed test in the report:

![image](https://github.com/clhobbs/events-splitter/assets/132529006/ac9c3087-8410-4ab5-95c7-f67b29dcc04c)

Note: I was not able to add this as a clickable link in the mochawesome report due to issue:  https://github.com/adamgruber/mochawesome/issues/208