### PR TITLE
chore: remove expose port in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ services:
     container_name: Target-2
     environment:
       APP_MODE: 'target'
-    expose:
-      - 9997
     networks:
       - events-net
     pull_policy: build
@@ -24,8 +22,6 @@ services:
     container_name: Target-1
     environment:
       APP_MODE: 'target'
-    expose: 
-      - 9997
     networks:
       - events-net
     depends_on:
@@ -42,8 +38,6 @@ services:
     container_name: Splitter
     environment:
       APP_MODE: 'splitter'
-    expose:
-      - 9997
     networks:
       - events-net
     depends_on:


### PR DESCRIPTION
Issue https://github.com/clhobbs/events-splitter/issues/11 points out that it is not necessary to `expose` port 9997 in any of the docker containers since all containers are on the same network. This PR simply removes the `expose` from the docker-compose.yml file.